### PR TITLE
Disable native tooltip

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@
 	var notificationHeight;
 
 	function addNotificationsDropdown() {
+		const $indicator = $('a.notification-indicator');
 		notificationHeight = $(window).height() * 2 / 3;
 		unreadNotificationsAvailable = true;
 		$('.notification-dropdown-ext-parent').remove();
-		$('a.notification-indicator').addClass('js-menu-target-ext');
-		$('a.notification-indicator').parent().append(`
+		$indicator.addClass('js-menu-target-ext');
+		$indicator.parent().append(`
 		<div class="dropdown-menu-content js-menu-content notification-dropdown-ext-parent">
 			<ul class="dropdown-menu dropdown-menu-sw">
 				<div class="dropdown-item" id="my-github-notification-list" 
@@ -16,6 +17,10 @@
 			</ul>
     	</div>
 		`);
+		
+		// Disable native tooltip
+		$indicator.removeAttr('aria-label');
+		$indicator.removeClass('tooltipped tooltipped-s');
 	}
 
 	function createMutationOberserver(selector, callback) {

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+.notification-indicator {
+    position: relative;
+}
+
 .user-nav a.notification-indicator~.dropdown-menu-content .dropdown-menu {
     width: 750px;
 }


### PR DESCRIPTION
The original tooltip overlaps the preview:

<img width="234" alt="" src="https://user-images.githubusercontent.com/1402241/29747963-65f4853a-8b35-11e7-83c9-8d8aa6f1650c.png">
