### PR TITLE
Avoid scrollable content

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,8 @@ function addNotificationsDropdown() {
 	const indicator = select('a.notification-indicator');
 	indicator.parentNode.insertAdjacentHTML('beforeend', `
 		<div id="NPG" class="dropdown-menu-content js-menu-content">
-			<ul id="NPG-dropdown" class="dropdown-menu dropdown-menu-sw">
-				<li id="NPG-item" class="notifications-list"></li>
-			</ul>
+			<div id="NPG-dropdown" class="dropdown-menu dropdown-menu-sw notifications-list">
+			</div>
 		</div>
 	`);
 }
@@ -76,7 +75,7 @@ async function openPopup() {
 		return;
 	}
 
-	const container = select('#NPG-item');
+	const container = select('#NPG-dropdown');
 	empty(container);
 	show(popup);
 	container.append(...notificationsList);

--- a/style.css
+++ b/style.css
@@ -6,16 +6,11 @@
     right: -1px;
 }
 
-#NPG-item {
-    overflow-y: auto;
-    max-height: calc(100vh - 60px);
-}
-
-#NPG-item .boxed-group {
+#NPG-dropdown .boxed-group {
     margin-bottom: 20px;
 }
 
-#NPG-item .boxed-group:last-child {
+#NPG-dropdown .boxed-group:last-child {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
Nested scrollviews are a bit annoying. Perhaps we can just leave it open and the user can scroll the whole page instead of a tiny _view_.