### PR TITLE
Use travis to auto-publish on new tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: node_js
 node_js:
   - 'node'
+env:
+  - EXTENSION_ID=kgilejfahkjidpaclkepbdoeioeohfmj
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: npm run release
+  on:
+    branch: master
+    tags: true

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Notifications Preview for GitHub",
   "homepage_url": "https://github.com/tanmayrajani/notifications-preview-github",
-  "version": "0.7.1",
+  "version": "0.0.0",
   "manifest_version": 2,
   "description": "Notifications Preview for GitHub with same page pop-over!",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "version": "0.0.0",
   "description": "Chrome extension",
   "scripts": {
-    "test": "xo"
+    "test": "xo",
+    "release": "npm run update-version && npm run upload",
+    "upload": "webstore upload --auto-publish",
+    "update-version": "dot-json manifest.json version $TRAVIS_TAG"
   },
   "license": "MIT",
   "devDependencies": {
+		"chrome-webstore-upload-cli": "^1.1.1",
+		"dot-json": "^1.0.3",
     "xo": "^0.18.2"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-		"chrome-webstore-upload-cli": "^1.1.1",
-		"dot-json": "^1.0.3",
+    "chrome-webstore-upload-cli": "^1.1.1",
+    "dot-json": "^1.0.3",
     "xo": "^0.18.2"
   },
   "xo": {


### PR DESCRIPTION
With this we'll be able to publish new version by just pushing new git tags or creating a new release [on github.com](https://github.com/tanmayrajani/notifications-preview-github/releases/new). The tag name will have to be exactly a version. For example `1.0.0`, not `v1.0.0`

Next: [How to generate Google API keys](https://github.com/DrewML/chrome-webstore-upload/blob/master/How%20to%20generate%20Google%20API%20keys.md#how-to-generate-google-api-keys). These will have to be stored on Travis, privately