### PR TITLE
Improve positioning on large notification counts

### DIFF
--- a/extension/style.css
+++ b/extension/style.css
@@ -49,6 +49,10 @@
     height: auto;
     padding: 2px;
     min-width: 1.5em;
+    
+    /* Position it so multiple digits don't go too far right */
+    left: 11px;
+    transform: translateX(-30%);
 
     font-size: 10px;
     font-weight: bold;


### PR DESCRIPTION
Triple-digit notifications extend too far right.

This change will move them slightly to the left without affecting 1-2 digits much.

# Before

<img width="90" alt="2 digits" src="https://user-images.githubusercontent.com/1402241/30517667-bc808cbc-9b90-11e7-9697-5032ba500e7d.png"> <img width="90" alt="3 digits" src="https://user-images.githubusercontent.com/1402241/30517669-be1c867a-9b90-11e7-8951-9ce49153768d.png"> <img width="90" alt="4 digits" src="https://user-images.githubusercontent.com/1402241/30517670-bfb0278a-9b90-11e7-8281-cbbd5d8f9188.png">

# After 

<img width="90" alt="2 digits" src="https://user-images.githubusercontent.com/1402241/30517671-c8b652be-9b90-11e7-8d5d-e4c85bb3f13c.png"> <img width="90" alt="3 digits" src="https://user-images.githubusercontent.com/1402241/30517672-ca94130a-9b90-11e7-93c3-62c9ca47677a.png"> <img width="90" alt="4 digits" src="https://user-images.githubusercontent.com/1402241/30517673-ccc133ce-9b90-11e7-9f80-e2ba626f61b7.png">

Not _perfect_ but I think it's good enough without limiting the number to 999, for example