### PR TITLE
Fix invalid DOM selector

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -51,7 +51,7 @@ function copyAttributes(elFrom, elTo) {
 }
 
 function sanitizeDOM(dom) {
-	for (const el of dom.querySelectorAll('script,[href^=data:],[href^=javascript:]')) {
+	for (const el of dom.querySelectorAll('script,[href^="data:"],[href^="javascript:"]')) {
 		el.remove();
 	}
 	for (const el of dom.querySelectorAll('*')) {


### PR DESCRIPTION
Firefox (at least) doesn't seem to like DOM selectors with attributes whose values are not quoted.

```js
document.querySelectorAll('script,[href^=data:],[href^=javascript:]')
> SyntaxError: 'script,[href^=data:],[href^=javascript:]' is not a valid selector
```
This results in a rejected fetch promise which breaks the addon :(

Adding quotes around the attribute's values seems to fix this:

```js
document.querySelectorAll('script,[href^="data:"],[href^="javascript:"]')
> NodeList [ <script>, <script>, <a.octotree_opts> ]
```

Apart from that: many thanks for publishing this addon on AMO and fixing the complaints of the reviewers! <3