### PR TITLE
fix selector change showing hidden avatars (compact mode)

### DIFF
--- a/extension/style.css
+++ b/extension/style.css
@@ -81,6 +81,6 @@
 
 /* Hide extra content */
 #NPG-dropdown.compact .age,
-#NPG-dropdown.compact .avatar-stack {
-    display: none;
+#NPG-dropdown.compact .AvatarStack {
+    display: none !important;
 }


### PR DESCRIPTION
- Fixes selector change (`.avatar-stack` to `.AvatarStack`) which started showing avatars in compact mode too.
- Had to add `!important` to override GitHub's own `!important`