### PR TITLE
Use `webext-base-css` to improve Option page’s style

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>Notifications Preview options</title>
 <title>Options • Notifications Preview for GitHub</title>
 <link rel="stylesheet" href="chrome://global/skin/in-content/common.css">
 <link rel="stylesheet" href="webext-base.css">

--- a/extension/options.html
+++ b/extension/options.html
@@ -4,7 +4,6 @@
 <title>Options • Notifications Preview for GitHub</title>
 <link rel="stylesheet" href="chrome://global/skin/in-content/common.css">
 <link rel="stylesheet" href="webext-base.css">
-<link rel="stylesheet" href="options.css">
 <form>
 	<p>
 		<label>

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,16 +1,10 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>Refined GitHub options</title>
-<style>
-	html {
-		font-family: sans-serif;
-	}
-	/* Increase spacing between sections */
-	h2 ~ h2,
-	form ~ form {
-		margin-top: 2em;
-	}
-</style>
+<title>Notifications Preview options</title>
+<title>Options • Notifications Preview for GitHub</title>
+<link rel="stylesheet" href="chrome://global/skin/in-content/common.css">
+<link rel="stylesheet" href="webext-base.css">
+<link rel="stylesheet" href="options.css">
 <form>
 	<p>
 		<label>

--- a/extension/webext-base.css
+++ b/extension/webext-base.css
@@ -1,0 +1,91 @@
+/*! https://npm.im/webext-base-css */
+
+/*
+`:not(*:root)` selectors are Chrome only
+`@-moz-document` rules are Firefox only
+`--in-content-box-background` variables are Firefox only
+*/
+
+:root {
+	min-width: 550px;
+	max-width: 700px;
+	margin: auto;
+}
+
+/* Selector matches Firefox’ */
+input[type='number'],
+input[type='password'],
+input[type='search'],
+input[type='text'],
+input[type='url'],
+input:not([type]),
+textarea {
+	display: block;
+	box-sizing: border-box;
+	margin-left: 0;
+	width: 100%;
+	resize: vertical;
+	-moz-tab-size: 4 !important;
+	tab-size: 4 !important;
+}
+
+input[type='checkbox'] {
+	vertical-align: -0.15em;
+}
+
+textarea:not(*:root):focus {
+	/* Missing from Chrome’s style https://github.com/chromium/chromium/blob/6bea0557fe67c9196dd2ec083e95fc5807674c87/extensions/renderer/resources/extension.css#L287 */
+	border-color: #4d90fe;
+	transition: border-color 200ms;
+}
+
+hr:not(*:root) {
+	margin-right: -17px;
+	margin-left: -17px;
+	border: none;
+	border-bottom: 1px solid #aaa4;
+}
+
+@-moz-document url-prefix('') {
+	:root {
+		background-color: #fff;
+	}
+
+	body {
+		min-height: 250px; /* Without this there's a white space in dark mode*/
+	}
+
+	body > * {
+		margin-left: 6px;
+		margin-right: 6px;
+	}
+
+	input[type='checkbox'] {
+		vertical-align: -0.4em;
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		background-color: var(--in-content-box-background, #292a2d);
+	}
+
+	body {
+		color: var(--in-content-page-color, #e8eaed);
+	}
+
+	a {
+		color: var(--in-content-link-color, #8ab4f8);
+	}
+
+	input[type='number'],
+	input[type='password'],
+	input[type='search'],
+	input[type='text'],
+	input[type='url'],
+	input:not([type]),
+	textarea {
+		color: inherit;
+		background-color: transparent;
+	}
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
       "browser",
       "webextensions"
     ]
+  },
+  "dependencies": {
+    "webext-base-css": "0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     ]
   },
   "dependencies": {
-    "webext-base-css": "0.0.1"
+    "webext-base-css": "^1.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/fregante/webext-base-css

<img width="390" alt="chrome" src="https://user-images.githubusercontent.com/1402241/77837858-4ff4b580-716e-11ea-8361-507f95c03318.png">
<img width="659" alt="firefox" src="https://user-images.githubusercontent.com/1402241/77837859-508d4c00-716e-11ea-936e-30913e588901.png">

