### PR TITLE
Make the whole area clickable

### DIFF
--- a/extension/github-notifications-preview.css
+++ b/extension/github-notifications-preview.css
@@ -110,6 +110,10 @@
     justify-content: space-between;
 }
 
+.NPG-dropdown .notifications-list-item > div {
+  flex: 1; /* expand to make whole area clickable */
+}
+
 .NPG-dropdown .d-flex.flex-column.flex-sm-row.flex-self-start.flex-items-center {
     /* Unread indicator and checkbox */
     display: none !important;


### PR DESCRIPTION
On short notifications only the `<a>` part is clickable. Expand the relevant parent to full width to make the whole area clickable.