### PR TITLE
Add gist.github.com support

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,8 @@
   },
   "content_scripts": [{
     "matches": [
-      "https://github.com/*"
+      "https://github.com/*",
+      "https://gist.github.com/*"
     ],
     "css": [
       "github-notifications-preview.css"


### PR DESCRIPTION
Currently the extension is not working in gist.github.com pages, 
i.e. there's no notification number in the blue bubble nor pop-over on hover.

This PR adds `https://gist.github.com/*` in the extension's manifest.json.
<sup>(I hope this change is all that's needed, because I couldn't get the loaded unpacked extension to work, I was getting errors)</sup>

Test URL:
https://gist.github.com/discover

Thank you