### PR TITLE
Change selector to work with global nav feature preview

### DIFF
--- a/source/github-notifications-preview.jsx
+++ b/source/github-notifications-preview.jsx
@@ -75,7 +75,7 @@ async function updateUnreadCount() {
 }
 
 function createNotificationsDropdown() {
-	const indicators = select.all('a.notification-indicator');
+	const indicators = select.all('notification-indicator a');
 	const participating = options.participating ? 'participating' : '';
 
 	for (const indicator of indicators) {


### PR DESCRIPTION
Switching to a selector which works for both existing navigation AND the new global navigation feature preview

(partially) fixes #143 