### PR TITLE
Cleanup popup closing code

### DIFF
--- a/source/github-notifications-preview.jsx
+++ b/source/github-notifications-preview.jsx
@@ -84,7 +84,7 @@ function createNotificationsDropdown() {
 		// https://github.com/tanmayrajani/notifications-preview-github/issues/50
 		const onClick = event => {
 			if (!event.metaKey && !event.ctrlKey && !event.shiftKey && event.target.closest('a[href]')) {
-				$('.modal-backdrop').click();
+				closeDropdown();
 			}
 		};
 

--- a/source/github-notifications-preview.jsx
+++ b/source/github-notifications-preview.jsx
@@ -181,7 +181,7 @@ async function openDropdown({currentTarget: indicator}) {
 }
 
 function closeDropdown() {
-	$('.NPG-container[open]').removeAttribute('open');
+	$('details.NPG-container[open] > summary').click();
 }
 
 // When the dropdown is open, GitHub's modal blocks all links outside the dropdown.


### PR DESCRIPTION
Following suggestions by @fregante from https://github.com/tanmayrajani/notifications-preview-github/pull/125#issuecomment-2267628773 and https://github.com/tanmayrajani/notifications-preview-github/pull/125#issuecomment-2269878016 after my PR was merged.

This PR makes these changes:

- replaces the old `$('.modal-backdrop').click()` (with the no longer applied `.modal-backdrop` selector) with a call to the new `closeDropdown` function (added in previous PR).
- in `closeDropdown` function:
  - replaces the unnecessary `.removeAttribute('open')` with `.click()`
  - replaces the selector with `details.NPG-container[open] > summary`

